### PR TITLE
Add unchecked iterators

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -33,10 +33,11 @@ namespace sigcpp
 		using size_type = size_t;
 		using difference_type = ptrdiff_t;
 
-		//using iterator = implementation-defined;
-		//using const_iterator = implementation - defined;
-		//using reverse_iterator = std::reverse_iterator<iterator>;
-		//using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+		//unchecked iterators: not standards-compliant; implementing for demo
+		using iterator = T*; 
+		using const_iterator = const T*;
+		using reverse_iterator = std::reverse_iterator<iterator>;
+		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 		//underlying array
 		value_type elements[N];
@@ -49,6 +50,57 @@ namespace sigcpp
 			std::swap_ranges(elements, elements + N, a.elements);
 		}
 
+		//iterators
+		constexpr iterator begin() noexcept 
+		{ 
+			return empty() ? nullptr : elements; 
+		}
+		
+		constexpr const_iterator begin() const noexcept 
+		{ 
+			return empty() ? nullptr : elements; 
+		}
+
+		constexpr iterator end() noexcept
+		{
+			return empty() ? nullptr : elements + N;
+		}
+
+		constexpr const_iterator end() const noexcept
+		{
+			return empty() ? nullptr : elements + N;
+		}
+
+		constexpr reverse_iterator rbegin() noexcept 
+		{ 
+			return reverse_iterator(end()); 
+		}
+		
+		constexpr const_reverse_iterator rbegin() const noexcept 
+		{ 
+			return const_reverse_iterator(end()); 
+		}
+		
+		constexpr reverse_iterator rend() noexcept
+		{
+			return reverse_iterator(begin());
+		}
+
+		constexpr const_reverse_iterator rend() const noexcept
+		{
+			return const_reverse_iterator(begin());
+		}
+
+		constexpr const_iterator cbegin() const noexcept { return begin(); }
+		constexpr const_iterator cend() const noexcept { return end(); }
+		
+		constexpr const_reverse_iterator crbegin() const noexcept 
+		{ 
+			return rbegin(); 
+		}
+		
+		constexpr const_reverse_iterator crend() const noexcept { return rend(); }
+
 		//capacity
 		constexpr bool empty() const noexcept { return N == 0; }
 		constexpr size_type size() const noexcept { return N; }
@@ -56,7 +108,11 @@ namespace sigcpp
 
 		//unchecked element access
 		constexpr reference operator[](size_type pos) { return elements[pos]; }
-		constexpr const_reference operator[](size_type pos) const { return elements[pos]; }
+		
+		constexpr const_reference operator[](size_type pos) const 
+		{ 
+			return elements[pos]; 
+		}
 
 		//checked element access
 		constexpr reference at(size_type pos)
@@ -73,11 +129,19 @@ namespace sigcpp
 		constexpr const_reference front() const { return elements[0]; }
 
 		constexpr reference back() { return empty() ? front() : elements[N-1]; }
-		constexpr const_reference back() const { return empty() ? front() : elements[N - 1]; }
+		
+		constexpr const_reference back() const 
+		{ 
+			return empty() ? front() : elements[N - 1]; 
+		}
 
 		//underlying raw data
 		constexpr pointer data() noexcept { return empty() ? nullptr : elements; }
-		constexpr const_pointer data() const noexcept { return empty() ? nullptr : elements; }
+		
+		constexpr const_pointer data() const noexcept 
+		{ 
+			return empty() ? nullptr : elements; 
+		}
 
 	}; //template array
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -29,6 +29,7 @@ int main()
    //non-empty array with partial init: last two elements are 0
    array<short, 5> p{ 8, -2, 7};
 
+
    //capacity
    test(!s.empty(), "s.empty()");
    test(s.size() == 3, "s.size()");
@@ -37,6 +38,7 @@ int main()
    test(!p.empty(), "p.empty()");
    test(p.size() == 5, "p.size()");
    test(p.max_size() == p.size(), "p.max_size()");
+
 
    //element access
    test(s[0] == 8, "s[0]");
@@ -65,10 +67,32 @@ int main()
    test(p.front() != -2, "p.front() != -2");
    test(p.back() == 0, "p.back()");
 
+
    //zero-size array
    array<char, 0> c;
    test(c.empty(), "c.empty()");
    //...more tests needed
+
+
+   //forward iterators
+   array<unsigned, 5> u{ 5, 9, 3, 1, 6 };
+   unsigned uExpected[] = { 5, 9, 3, 1, 6 };
+
+   bool iteratorTest = true;
+   std::size_t i = 0;
+   for (auto it = u.begin(); it != u.end() && iteratorTest; it++, i++)
+      iteratorTest = *it == uExpected[i];
+   test(iteratorTest, "forward iterator");
+
+   //reverse iterators
+   unsigned urExpected[] = { 6, 1, 3, 9, 5 };
+
+   iteratorTest = true;
+   i = 0;
+   for (auto it = u.rbegin(); it != u.rend() && iteratorTest; it++, i++)
+      iteratorTest = *it == urExpected[i];
+   test(iteratorTest, "reverse iterator");
+
 
    //fill
    array<char, 5> a;
@@ -76,11 +100,11 @@ int main()
 
    //test until one of the elements is *not* the fill value
    //-false from any_of call means fill succeeded
-   //-use data() member because array template doesn't yet support iters
-   bool fillTest = !std::any_of(a.data(), a.data() + a.size(), 
+   bool fillTest = !std::any_of(a.begin(), a.end(), 
                                 [](char c) { return c != 'x'; }
                                );
    test(fillTest, "a.fill()");
+
 
    //swap
    array<int, 3> m{ 8, 5, 4 };
@@ -91,9 +115,10 @@ int main()
    m.swap(n);
 
    bool swapTest = true;
-   for (std::size_t i = 0; i < 3 && swapTest; i++)
+   for (std::size_t i = 0; i < m.size() && swapTest; i++)
       swapTest = m[i] == mExpected[i] && n[i] == nExpected[i];
    test(swapTest, "m.swap(n)");
+
 
    //summarize
    summarizeTests();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -68,12 +68,6 @@ int main()
    test(p.back() == 0, "p.back()");
 
 
-   //zero-size array
-   array<char, 0> c;
-   test(c.empty(), "c.empty()");
-   //...more tests needed
-
-
    //forward iterators
    array<unsigned, 5> u{ 5, 9, 3, 1, 6 };
    unsigned uExpected[] = { 5, 9, 3, 1, 6 };
@@ -92,6 +86,16 @@ int main()
    for (auto it = u.rbegin(); it != u.rend() && iteratorTest; it++, i++)
       iteratorTest = *it == urExpected[i];
    test(iteratorTest, "reverse iterator");
+
+   //zero-size array
+   array<char, 0> c;
+   test(c.empty(), "c.empty()");
+
+   //iterator on empty array: the loop body should not execute
+   iteratorTest = true;
+   for (const auto e : c)
+      iteratorTest = false;
+   test(iteratorTest, "fwd iterator on empty array");
 
 
    //fill
@@ -115,8 +119,8 @@ int main()
    m.swap(n);
 
    bool swapTest = true;
-   for (std::size_t i = 0; i < m.size() && swapTest; i++)
-      swapTest = m[i] == mExpected[i] && n[i] == nExpected[i];
+   for (std::size_t idx = 0; idx < m.size() && swapTest; idx++)
+      swapTest = m[idx] == mExpected[idx] && n[idx] == nExpected[idx];
    test(swapTest, "m.swap(n)");
 
 


### PR DESCRIPTION
The commits in this PR add "unchecked iterators" to the array template. The unchecked iterator's type is T*. This iterator is not standards-compliant, but adding it to illustrate iterator basics without the overhead of a standards-compliant iterator.

The commits also include unit tests for iterators. 