### PR TITLE
Add a standards-compliant unchecked array iterator template

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -7,7 +7,9 @@
 * That information may be relocated but be conspicuous in all derived work.
 * 
 * Define a class template for arrays
-* - see C++17 [array.overview] https://timsong-cpp.github.io/cppwp/n4659/array
+* - see C++17 [array.overview], [array.syn]
+* - https://timsong-cpp.github.io/cppwp/n4659/array
+* - https://timsong-cpp.github.io/cppwp/n4659/array.syn
 */
 
 #ifndef SIGCPP_ARRAY_H
@@ -18,6 +20,8 @@
 #include <utility>
 #include <algorithm>
 #include <type_traits>
+
+#include "array_iterator.h"
 
 namespace sigcpp
 {
@@ -33,9 +37,8 @@ namespace sigcpp
 		using size_type = size_t;
 		using difference_type = ptrdiff_t;
 
-		//unchecked iterators: not standards-compliant; implementing for demo
-		using iterator = T*; 
-		using const_iterator = const T*;
+		using iterator = array_iterator<pointer>; 
+		using const_iterator = array_iterator<const_pointer>;
 		using reverse_iterator = std::reverse_iterator<iterator>;
 		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -56,7 +59,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements; 
+				return array_iterator(elements); 
 		}
 		
 		constexpr const_iterator begin() const noexcept 
@@ -64,7 +67,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements;
+				return array_iterator(elements);
 		}
 
 		constexpr iterator end() noexcept
@@ -72,7 +75,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements + N;
+				return array_iterator(elements + N);
 		}
 
 		constexpr const_iterator end() const noexcept
@@ -80,7 +83,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements + N;
+				return array_iterator(elements + N);
 		}
 
 		constexpr reverse_iterator rbegin() noexcept 

--- a/include/array.h
+++ b/include/array.h
@@ -58,51 +58,42 @@ namespace sigcpp
 		}
 
 		//iterators
-		constexpr iterator begin() noexcept 
-		{ 
-			return const_cast<iterator>(_begin());
-		}
-		
-		constexpr const_iterator begin() const noexcept { return _begin(); }
-
-		constexpr iterator end() noexcept
-		{
-			return const_cast<iterator>(_end());
-		}
-
-		constexpr const_iterator end() const noexcept { return _end(); }
+		constexpr iterator begin() noexcept { return _iterator(); }
+		constexpr const_iterator begin() const noexcept { return _cIterator(); }
+		constexpr iterator end() noexcept { return _iterator(N); }
+		constexpr const_iterator end() const noexcept { return _cIterator(N); }
 
 		constexpr reverse_iterator rbegin() noexcept 
 		{ 
-			return reverse_iterator(const_cast<iterator>(_end()));
+			return reverse_iterator(_iterator(N));
 		}
 		
 		constexpr const_reverse_iterator rbegin() const noexcept 
 		{ 
-			return const_reverse_iterator(_end()); 
+			return const_reverse_iterator(_cIterator(N));
 		}
 		
 		constexpr reverse_iterator rend() noexcept
 		{
-			return reverse_iterator(const_cast<iterator>(_begin()));
+			return reverse_iterator(_iterator());
 		}
 
 		constexpr const_reverse_iterator rend() const noexcept
 		{
-			return const_reverse_iterator(_begin());
+			return const_reverse_iterator(_cIterator());
 		}
 
-		constexpr const_iterator cbegin() const noexcept { return _begin(); }
-		constexpr const_iterator cend() const noexcept { return _end(); }
+		constexpr const_iterator cbegin() const noexcept { return _cIterator(); }
+		constexpr const_iterator cend() const noexcept { return _cIterator(N); }
 		
 		constexpr const_reverse_iterator crbegin() const noexcept 
 		{ 
-			return reverse_iterator(const_cast<iterator>(_end()));
+			return const_reverse_iterator(_cIterator(N));
 		}
 		
 		constexpr const_reverse_iterator crend() const noexcept 
 		{ 
-			return const_reverse_iterator(_begin());
+			return const_reverse_iterator(_cIterator());
 		}
 
 		//capacity
@@ -130,7 +121,6 @@ namespace sigcpp
 		constexpr const_reference front() const { return values[0]; }
 
 		constexpr reference back() { return const_cast<reference>(_back()); }
-
 		constexpr const_reference back() const { return _back(); }
 
 		//underlying raw data
@@ -143,20 +133,20 @@ namespace sigcpp
 
 	private:
 		//utility functions to eliminate redundancy in public members
-		constexpr const_iterator _begin() const noexcept
+		constexpr iterator _iterator(difference_type n = 0) noexcept
 		{
 			if constexpr (N == 0)
 				return iterator();
 			else
-				return iterator(values);
+				return iterator(values + n);
 		}
 
-		constexpr const_iterator _end() const noexcept
+		constexpr const_iterator _cIterator(difference_type n = 0) const noexcept
 		{
 			if constexpr (N == 0)
-				return iterator();
+				return const_iterator();
 			else
-				return iterator(values + N);
+				return const_iterator(values + n);
 		}
 
 		constexpr const_reference _at(size_type pos) const

--- a/include/array.h
+++ b/include/array.h
@@ -4,8 +4,8 @@
 * (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
 *
 * Attribution and copyright notice shown on lines 3 and 4 must be retained.
-* That information may be relocated but be conspicuous in all derived work.
-* 
+* That info may be relocated but it must be conspicuous in all derived work.
+*
 * Define a class template for arrays
 * - see C++17 [array.overview], [array.syn]
 * - https://timsong-cpp.github.io/cppwp/n4659/array
@@ -37,53 +37,54 @@ namespace sigcpp
 		using size_type = size_t;
 		using difference_type = ptrdiff_t;
 
+		//unchecked iterators: simple but standards-compliant
 		using iterator = array_iterator<pointer>; 
 		using const_iterator = array_iterator<const_pointer>;
 		using reverse_iterator = std::reverse_iterator<iterator>;
 		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 		//underlying array
-		value_type elements[N];
+		value_type values[N];
 
 		//utility
-		void fill(const T& u) { std::fill_n(elements, N, u); }
+		void fill(const T& u) { std::fill_n(values, N, u); }
 
 		void swap(array& a) noexcept(std::is_nothrow_swappable_v<T>)
 		{
-			std::swap_ranges(elements, elements + N, a.elements);
+			std::swap_ranges(values, values + N, a.values);
 		}
 
 		//iterators
 		constexpr iterator begin() noexcept 
 		{ 
 			if constexpr (N == 0)
-				return nullptr;
+				return iterator();
 			else
-				return array_iterator(elements); 
+				return iterator(values); 
 		}
 		
 		constexpr const_iterator begin() const noexcept 
 		{ 
 			if constexpr (N == 0)
-				return nullptr;
+				return const_iterator();
 			else
-				return array_iterator(elements);
+				return const_iterator(values);
 		}
 
 		constexpr iterator end() noexcept
 		{
 			if constexpr (N == 0)
-				return nullptr;
+				return iterator();
 			else
-				return array_iterator(elements + N);
+				return iterator(values + N);
 		}
 
 		constexpr const_iterator end() const noexcept
 		{
 			if constexpr (N == 0)
-				return nullptr;
+				return const_iterator();
 			else
-				return array_iterator(elements + N);
+				return const_iterator(values + N);
 		}
 
 		constexpr reverse_iterator rbegin() noexcept 
@@ -122,18 +123,18 @@ namespace sigcpp
 		constexpr size_type max_size() const noexcept { return N; }
 
 		//unchecked element access
-		constexpr reference operator[](size_type pos) { return elements[pos]; }
+		constexpr reference operator[](size_type pos) { return values[pos]; }
 		
 		constexpr const_reference operator[](size_type pos) const 
 		{ 
-			return elements[pos]; 
+			return values[pos]; 
 		}
 
 		//checked element access
 		constexpr reference at(size_type pos)
 		{
 			if (pos < N)
-				return elements[pos];
+				return values[pos];
 			else
 				throw new std::out_of_range("array index out of range");
 		}
@@ -141,22 +142,22 @@ namespace sigcpp
 		constexpr const_reference at(size_type pos) const
 		{
 			if (pos < N)
-				return elements[pos];
+				return values[pos];
 			else
 				throw new std::out_of_range("array index out of range");
 		}
 
-		constexpr reference front() { return elements[0]; }
-		constexpr const_reference front() const { return elements[0]; }
+		constexpr reference front() { return values[0]; }
+		constexpr const_reference front() const { return values[0]; }
 
-		constexpr reference back() { return empty() ? front() : elements[N-1]; }
+		constexpr reference back() { return empty() ? front() : values[N-1]; }
 		
 		constexpr const_reference back() const 
 		{ 
 			if constexpr (N == 0)
 				return front();
 			else
-				return elements[N - 1];
+				return values[N - 1];
 		}
 
 		//underlying raw data
@@ -165,7 +166,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements;
+				return values;
 		}
 
 		constexpr const_pointer data() const noexcept 
@@ -173,7 +174,7 @@ namespace sigcpp
 			if constexpr (N == 0)
 				return nullptr;
 			else
-				return elements;
+				return values;
 		}
 
 	}; //template array

--- a/include/array_iterator.h
+++ b/include/array_iterator.h
@@ -1,0 +1,143 @@
+/*
+* array_iterator.h
+* Sean Murthy
+* (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
+*
+* Attribution and copyright notice shown on lines 3 and 4 must be retained.
+* That information may be relocated but be conspicuous in all derived work.
+*
+* Define a template for random-access iterators: wraps a raw array
+* - see C++17 [iterator.requirements]
+* - https://timsong-cpp.github.io/cppwp/n4659/iterator.requirements
+*/
+
+#ifndef SIGCPP_ARRAY_ITERATOR_H
+#define SIGCPP_ARRAY_ITERATOR_H
+
+#include <cstddef>
+#include <iterator>
+
+namespace sigcpp
+{
+	template<typename P> //P is a pointer type
+	class array_iterator
+	{
+	public:
+
+		//types
+		using iterator_category = typename std::iterator_traits<P>::iterator_category;
+		using value_type = typename std::iterator_traits<P>::value_type;
+		using difference_type = typename std::iterator_traits<P>::difference_type;
+		using pointer = typename std::iterator_traits<P>::pointer;
+		using reference = typename std::iterator_traits<P>::reference;
+
+		//ctors
+		array_iterator() noexcept = default;
+		array_iterator(P p) noexcept : basePtr(p){}
+
+		//the wrapped iter
+		constexpr P base() const noexcept { return basePtr; }
+
+		//dereference and member access
+		constexpr reference operator*() const { return *basePtr; }
+		constexpr pointer operator->() const noexcept { return basePtr; }
+		
+		//element access
+		constexpr reference operator[](difference_type n) const
+		{
+			return basePtr[n];
+		}
+
+		//increment and decrement
+		constexpr array_iterator& operator++() 
+		{
+			++basePtr;
+			return *this;
+		}
+
+		constexpr array_iterator operator++(int) 
+		{
+			array_iterator beforeIncrement = *this;
+			++basePtr;
+			return beforeIncrement;
+		}
+
+		constexpr array_iterator& operator--() 
+		{
+			--basePtr;
+			return *this;
+		}
+
+		constexpr array_iterator operator--(int) 
+		{
+			array_iterator beforeDecrement = *this;
+			--basePtr;
+			return beforeDecrement;
+		}
+
+		//arithmetic
+		constexpr array_iterator operator+(difference_type n) const
+		{
+			array_iterator t = *this;
+			t += n;
+			return t;
+		}
+
+		constexpr array_iterator operator-(difference_type n) const
+		{
+			array_iterator t = *this;
+			t -= n;
+			return t;
+		}
+
+		array_iterator& operator+=(difference_type n)
+		{
+			basePtr += n;
+			return *this;
+		}
+
+		array_iterator& operator-=(difference_type n)
+		{
+			basePtr -= n;
+			return *this;
+		}
+
+		//comparison
+		constexpr bool operator==(const array_iterator& r) const 
+		{
+			return basePtr == r.basePtr;
+		}
+
+		constexpr bool operator!=(const array_iterator& r) const
+		{
+			return basePtr != r.basePtr;
+		}
+
+		constexpr bool operator<(const array_iterator& r) const
+		{
+			return basePtr < r.basePtr;
+		}
+
+		constexpr bool operator>(const array_iterator& r) const
+		{
+			return basePtr > r.basePtr;
+		}
+
+		constexpr bool operator<=(const array_iterator& r) const
+		{
+			return !(r > *this);
+		}
+
+		constexpr bool operator>=(const array_iterator& r) const
+		{
+			return !(*this < r);
+		}
+
+	private:
+		P basePtr{ nullptr };
+
+	}; //template array_iterator
+
+}	//namespace sigcpp
+
+#endif

--- a/include/array_iterator.h
+++ b/include/array_iterator.h
@@ -4,7 +4,7 @@
 * (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
 *
 * Attribution and copyright notice shown on lines 3 and 4 must be retained.
-* That information may be relocated but be conspicuous in all derived work.
+* That info may be relocated but it must be conspicuous in all derived work.
 *
 * Define a template for random-access iterators: wraps a raw array
 * - see C++17 [iterator.requirements]


### PR DESCRIPTION
The commits in this PR add a standards-compliant unchecked array iterator. They also change the array template to use the newly defined iterator template.

The iterator simply wraps a raw array. If `T` is the value type, the template is parameterized only on `T*`. The template is not parameterized by array size so that the same iterator template may be used even with dynamically-sized arrays (for example, vectors). For simplicity, the iterator's ctor also does not accept a size parameter, making the iterator completely unchecked. A possible improvement is to add a size (or such parameter) to the ctor so that operations can be checked.