### PR TITLE
Reorg test driver

### DIFF
--- a/test/array-test.cpp
+++ b/test/array-test.cpp
@@ -12,39 +12,15 @@
 * - see C++17 [array.overview] https://timsong-cpp.github.io/cppwp/n4659/array
 */
 
-#include <iostream>
-#include <exception>
 #include <algorithm>
-#include <string>
 
 #include "../include/array.h"
 
 #include "tester.h"
 
-using std::cout;
-
-
-void runTests();
-
-int main()
-{
-   try
-   {
-      cout << "Running tests: ";
-      runTests();
-   }
-   catch (const std::string& msg)
-   {
-      cout << msg << '\n';
-   }
-
-   summarizeTests();
-}
-
 void runTests()
 {
    using sigcpp::array;
-
 
    //non-empty array with full init
    array<short, 3> s{ 8, -2, 7 };
@@ -54,41 +30,41 @@ void runTests()
 
 
    //capacity
-   assert(!s.empty(), "s.empty()");
-   assert(s.size() == 3, "s.size()");
-   assert(s.max_size() == s.size(), "s.max_size()");
+   verify(!s.empty(), "s.empty()");
+   verify(s.size() == 3, "s.size()");
+   verify(s.max_size() == s.size(), "s.max_size()");
 
-   assert(!p.empty(), "p.empty()");
-   assert(p.size() == 5, "p.size()");
-   assert(p.max_size() == p.size(), "p.max_size()");
+   verify(!p.empty(), "p.empty()");
+   verify(p.size() == 5, "p.size()");
+   verify(p.max_size() == p.size(), "p.max_size()");
 
 
    //element access
-   assert(s[0] == 8, "s[0]");
-   assert(s[1] == -2, "s[1]");
-   assert(s[2] == 7, "s[2]");
-   assert(s[1] != 8, "s[1] != 8");
+   verify(s[0] == 8, "s[0]");
+   verify(s[1] == -2, "s[1]");
+   verify(s[2] == 7, "s[2]");
+   verify(s[1] != 8, "s[1] != 8");
 
-   assert(p[0] == 8, "p[0]");
-   assert(p[2] == 7, "p[2]");
-   assert(p[4] == 0, "p[4]");
+   verify(p[0] == 8, "p[0]");
+   verify(p[2] == 7, "p[2]");
+   verify(p[4] == 0, "p[4]");
 
-   assert(s.at(0) == 8, "s.at(0)");
-   assert(s.at(1) == -2, "s.at(1)");
-   assert(s.at(2) == 7, "s.at(2)");
+   verify(s.at(0) == 8, "s.at(0)");
+   verify(s.at(1) == -2, "s.at(1)");
+   verify(s.at(2) == 7, "s.at(2)");
 
-   assert(p.at(0) == 8, "p.at(0)");
-   assert(p.at(2) == 7, "p.at(2)");
-   assert(p.at(4) == 0, "p.at(4)");
+   verify(p.at(0) == 8, "p.at(0)");
+   verify(p.at(2) == 7, "p.at(2)");
+   verify(p.at(4) == 0, "p.at(4)");
 
-   assert(s.front() == 8, "s.front()");
-   assert(s.front() != -2, "s.front() != -2");
-   assert(s.back() == 7, "s.back()");
-   assert(s.back() != -2, "s.back() != -2");
+   verify(s.front() == 8, "s.front()");
+   verify(s.front() != -2, "s.front() != -2");
+   verify(s.back() == 7, "s.back()");
+   verify(s.back() != -2, "s.back() != -2");
 
-   assert(p.front() == 8, "p.front()");
-   assert(p.front() != -2, "p.front() != -2");
-   assert(p.back() == 0, "p.back()");
+   verify(p.front() == 8, "p.front()");
+   verify(p.front() != -2, "p.front() != -2");
+   verify(p.back() == 0, "p.back()");
 
 
    //forward iterators
@@ -99,7 +75,7 @@ void runTests()
    std::size_t i = 0;
    for (auto it = u.begin(); it != u.end() && iteratorTest; ++it, ++i)
       iteratorTest = *it == uExpected[i];
-   assert(iteratorTest, "forward iterator");
+   verify(iteratorTest, "forward iterator");
 
    //reverse iterators
    unsigned urExpected[] = { 6, 1, 3, 9, 5 };
@@ -108,17 +84,17 @@ void runTests()
    i = 0;
    for (auto it = u.rbegin(); it != u.rend() && iteratorTest; ++it, ++i)
       iteratorTest = *it == urExpected[i];
-   assert(iteratorTest, "reverse iterator");
+   verify(iteratorTest, "reverse iterator");
 
    //zero-size array
    array<char, 0> c;
-   assert(c.empty(), "c.empty()");
+   verify(c.empty(), "c.empty()");
 
    //iterator on empty array: the loop body should not execute
    iteratorTest = true;
    for (const auto e : c)
       iteratorTest = false;
-   assert(iteratorTest, "fwd iterator on empty array");
+   verify(iteratorTest, "fwd iterator on empty array");
 
 
    //fill
@@ -130,7 +106,7 @@ void runTests()
    bool fillTest = !std::any_of(a.begin(), a.end(), 
                                 [](char c) { return c != 'x'; }
                                );
-   assert(fillTest, "a.fill()");
+   verify(fillTest, "a.fill()");
 
 
    //swap
@@ -144,19 +120,5 @@ void runTests()
    bool swapTest = true;
    for (std::size_t idx = 0; idx < m.size() && swapTest; ++idx)
       swapTest = m[idx] == mExpected[idx] && n[idx] == nExpected[idx];
-   assert(swapTest, "m.swap(n)");
-}
-
-
-//print content of any collection
-template<typename ForwardIt>
-void print(ForwardIt first, ForwardIt last, const char* heading = nullptr)
-{
-   if (heading)
-      cout << heading << ": ";
-
-   for (; first != last; ++first)
-      cout << *first << ' ';
-
-   cout << '\n';
+   verify(swapTest, "m.swap(n)");
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,42 @@
+/*
+* main.cpp
+* Sean Murthy
+* (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
+*
+* Attribution and copyright notice must be retained.
+* - Attribution may be augmented to include additional authors
+* - Copyright notice cannot be altered
+* Attribution and copyright info may be relocated but they must be conspicuous.
+*
+* Intialize tester and start a specific set of unit tests
+*/
+
+#include <iostream>
+#include <string>
+#include <array>
+
+#include "tester.h"
+
+//must be defined in a unit-specific source file such as "array-test.cpp"
+void runTests();
+
+int main()
+{
+   //TODO: configure the tester based on cmd-line
+
+   std::array<int, 0> a;
+
+   try
+   {
+      std::cout << "Running tests: "; //TODO: conditionally print: which destination?
+      runTests();
+   }
+   catch (const std::string& msg)
+   {
+      std::cout << msg << '\n'; //TODO: print in appropriate stream based in cmd-line
+   }
+   //TODO handle other exceptions
+
+   //TODO: conditionally print summary to appropriate destination
+   summarizeTests();
+}

--- a/test/test-stl-lite.vcxproj
+++ b/test/test-stl-lite.vcxproj
@@ -85,14 +85,15 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/w14061 /w14062 /w14242 /w14254 /w14266 /w14287 /w14296 /w14355 /w14547 /w14548 /w14549 /w14555 /w14596 /w14608 /w14738 /w14800 /w14822 /w14946 /w14986 /w15038 %(AdditionalOptions)</AdditionalOptions>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -101,11 +102,14 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -114,8 +118,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -124,6 +127,8 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/w14061 /w14062 /w14242 /w14254 /w14266 /w14287 /w14296 /w14355 /w14547 /w14548 /w14549 /w14555 /w14596 /w14608 /w14738 /w14800 /w14822 /w14946 /w14986 /w15038 %(AdditionalOptions)</AdditionalOptions>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,8 +139,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -144,6 +148,8 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/w14061 /w14062 /w14242 /w14254 /w14266 /w14287 /w14296 /w14355 /w14547 /w14548 /w14549 /w14555 /w14596 /w14608 /w14738 /w14800 /w14822 /w14946 /w14986 /w15038 %(AdditionalOptions)</AdditionalOptions>
+      <PrecompiledHeaderFile />
+      <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -154,6 +160,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="array-test.cpp" />
+    <ClCompile Include="main.cpp" />
     <ClCompile Include="tester.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/test-stl-lite.vcxproj.filters
+++ b/test/test-stl-lite.vcxproj.filters
@@ -21,5 +21,8 @@
     <ClCompile Include="tester.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -12,7 +12,6 @@
 */
 
 #include <iostream>
-#include <exception>
 #include <sstream>
 #include <climits>
 
@@ -44,7 +43,7 @@ static unsigned testsFailed;
 bool lastOutputEndedInLineBreak{ false };
 
 //track number of tests and check test result
-void assert(bool success, const char* hint)
+void verify(bool success, const char* hint)
 {
    ++testsDone;
    std::ostringstream message;

--- a/test/tester.h
+++ b/test/tester.h
@@ -17,5 +17,5 @@ void setPassReportMode(passReportMode mode);
 void setFailThreshold(unsigned short value);
 void setMaxFailThreshold();
 
-void assert(bool success, const char* msg);
+void verify(bool success, const char* msg);
 void summarizeTests();


### PR DESCRIPTION
The commits in this PR collectively make the following changes:

- Remove `main` function from `array-test.cpp`
- Add file `main.cpp`: contains `main` function
- Rename function `assert` to `verify` in `tester.cpp` so that the std `assert` macro can be freely used if necessary
- Adjust properties of VStudio solution and project

**Note:** The active configuration for the VStudio project is set to "Debug x86". However, it appears a previous commit had the platform set to x64 instead of x86, though I am fairly certain that the platform was set to x86. It is unclear if a missing VStudio file (from the repo) is responsible for this behavior, or if I had inadvertently set the platform to x64. We need to keep an eye on a possible issue.    