### PR TITLE
Generalize array-template type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Students and faculty from any university, anywhere in the world, are welcome.
 
 ## Contact
 
-E-mail `sigcpp` at the domain `outlook.com`. Please include an appropriate subject line.
+Please use the contact information on the [SIGCPP web site](https://sigcpp.github.io/).

--- a/include/array.h
+++ b/include/array.h
@@ -33,10 +33,10 @@ namespace sigcpp
 	{
 		//types
 		using value_type = T;
-		using pointer = T*;
-		using const_pointer = const T*;
-		using reference = T&;
-		using const_reference = const T&;
+		using pointer = value_type*;
+		using const_pointer = const value_type*;
+		using reference = value_type&;
+		using const_reference = const value_type&;
 		using size_type = std::size_t;
 		using difference_type = std::ptrdiff_t;
 


### PR DESCRIPTION
The commits in this PR generalize the type aliases in the array template. They also make a minor change to the contact information in the repo's README.