### PR TITLE
Initial version of command-line support for test driver

### DIFF
--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -77,8 +77,7 @@ void processCmdLine(char* arguments[], const size_t size)
          printSummary = (value == option_value_yes);
       else if (option_name == option_name_threshold)
       {
-         const string_view& v = arguments[i + 1];
-         std::from_chars(v.data(), v.data() + v.size(), failThreshold);
+         std::from_chars(value.data(), value.data() + value.size(), failThreshold);
          setFailThreshold(failThreshold);
       }
       else if (option_name == option_name_file || option_name == option_name_file_overwrite ||

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -30,7 +30,7 @@ using std::size_t;
 //must be defined in a unit-specific source file such as "array-test.cpp"
 void runTests();
 
-void processCmdLine(char* arguments[], const size_t size);
+void processCmdLine(char* arguments[], const std::size_t size);
 
 void replace_all(std::string& str, const std::string& substr, 
    const std::string& new_substr);

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -172,7 +172,7 @@ void processCmdLine(char* arguments[], const size_t size)
 }
 
 //Replace all instances of a substring with a different substring
-void replace_all(std::string& str, std::const string& substr, 
+void replace_all(std::string& str, const std::string& substr, 
    const std::string& new_substr)
 {
   auto pos = str.find(substr);

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -26,7 +26,7 @@
 void runTests();
 
 void processCmdLine(char* arguments[], const std::size_t size);
-passReportMode getPassReportMode(const std::string_view value);
+passReportMode getPassReportMode(const std::string_view& value);
 
 void replace_all(std::string& str, const std::string& substr, 
    const std::string& new_substr);
@@ -177,7 +177,7 @@ void replace_all(std::string& str, const std::string& substr,
 
 
 //convert text version of pass report mode to enum equivalent
-passReportMode getPassReportMode(const std::string_view value)
+passReportMode getPassReportMode(const std::string_view& value)
 {
    constexpr std::string_view value_none{ "none" }, 
                               value_indicate{ "indicate" },

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -52,50 +52,51 @@ void processCmdLine(char* arguments[], const size_t size)
    string_view fileOpenMode;
    string outputFilename;
 
-   constexpr string_view name_header{ "-h" }, name_header_text{ "-ht" },
-      name_summary{ "-s" }, namePRM{ "-p" }, name_file{ "-f" },
-      name_file_overwrite{ "-fo" }, name_file_append{ "-fa" },
-      name_threshold{ "-t" };
+   constexpr string_view option_name_header{ "-h" }, option_name_header_text{ "-ht" },
+      option_name_summary{ "-s" }, option_name_prm{ "-p" }, option_name_file{ "-f" },
+      option_name_file_overwrite{ "-fo" }, option_name_file_append{ "-fa" },
+      option_name_threshold{ "-t" };
 
-   constexpr string_view value_yes{ "yes" };
-   constexpr string_view value_detail{ "detail" },
-      value_indicate{ "indicate" }, value_none{ "none" }, value_auto{ "auto" };
+   constexpr string_view option_value_yes{ "yes" };
+   constexpr string_view option_value_detail{ "detail" },
+      option_value_indicate{ "indicate" }, option_value_none{ "none" },
+      option_value_auto{ "auto" };
 
    //begin parsing cmd-line arguments
    for (size_t i = 1; i < size; i += 2)
    {
-      string_view name(arguments[i]), value(arguments[i + 1]);
+      string_view option_name(arguments[i]), value(arguments[i + 1]);
       
-      if (name == name_header)
-         printHeader = (value == value_yes);
-      else if (name == name_header_text)
+      if (option_name == option_name_header)
+         printHeader = (value == option_value_yes);
+      else if (option_name == option_name_header_text)
          headerText = value;
-      else if (name == namePRM)
+      else if (option_name == option_name_prm)
          passReportMode = value;
-      else if (name == name_summary)
-         printSummary = (value == value_yes);
-      else if (name == name_threshold)
+      else if (option_name == option_name_summary)
+         printSummary = (value == option_value_yes);
+      else if (option_name == option_name_threshold)
       {
          const string_view& v = arguments[i + 1];
          std::from_chars(v.data(), v.data() + v.size(), failThreshold);
          setFailThreshold(failThreshold);
       }
-      else if (name == name_file || name == name_file_overwrite ||
-         name == name_file_append)
+      else if (option_name == option_name_file || option_name == option_name_file_overwrite ||
+         option_name == option_name_file_append)
       {
-         fileOpenMode = name;
+         fileOpenMode = option_name;
          outputFilename = value;
       }
    } //done parsing cmd-line arguments
 
    //set pass report mode to the proper value
-   if (passReportMode == value_detail)
+   if (passReportMode == option_value_detail)
        setPassReportMode(passReportMode::detail);
-   else if (passReportMode == value_indicate)
+   else if (passReportMode == option_value_indicate)
        setPassReportMode(passReportMode::indicate);
-   else if (passReportMode == value_none)
+   else if (passReportMode == option_value_none)
        setPassReportMode(passReportMode::none);
-   else if (passReportMode == value_auto)
+   else if (passReportMode == option_value_auto)
    {
       //if output to file option enabled
       if (!fileOpenMode.empty())
@@ -141,14 +142,14 @@ void processCmdLine(char* arguments[], const size_t size)
       if (fileOutPath.extension() == "")
          fileOutPath.replace_extension(".out");
       //if -f option enabled, make sure the file doesn't already exist
-      if (fileOpenMode == name_file && std::filesystem::exists(fileOutPath))
+      if (fileOpenMode == option_name_file && std::filesystem::exists(fileOutPath))
       {
          std::cerr << "Output file alredy exists";
          return;
       }
       //if -fa option is enabled, set open mode to append
       using std::ios;
-      fileOut.open(fileOutPath, fileOpenMode == name_file_append ? ios::app : ios::out);
+      fileOut.open(fileOutPath, fileOpenMode == option_name_file_append ? ios::app : ios::out);
       //check for errors opening file
       if (!fileOut.is_open())
       {

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -48,7 +48,7 @@ void processCmdLine(char* arguments[], const std::size_t size)
    bool printHeader{ true };
    bool printSummary{ true };
    string headerText("Running $exe");
-   string_view passReportMode;
+   string_view passReportMode; // empty value treated as "auto" in getPassReportMode
    unsigned short failThreshold(0);
    string_view fileOpenMode;
    string outputFilename;

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -25,7 +25,6 @@
 
 using std::string;
 using std::string_view;
-using std::ios;
 
 //must be defined in a unit-specific source file such as "array-test.cpp"
 void runTests();
@@ -108,7 +107,6 @@ void processCmdLine(const std::vector<string_view>& arguments)
       for (; pos != string::npos; pos = headerText.find("$exe"))
          headerText.replace(pos, 4, filenameNoExt);
    }
-   //else do not print a header text
    else
       headerText = "";
 
@@ -141,8 +139,8 @@ void processCmdLine(const std::vector<string_view>& arguments)
          std::cerr << "Output file alredy exists";
          return;
       }
-
       //if -fa option is enabled, set open mode to append
+      using std::ios;
       fileOut.open(fileOutPath, fileOpenMode == "-fa" ? ios::app : ios::out);
       //check for errors opening file
       if (!fileOut.is_open())

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -23,10 +23,6 @@
 
 #include "tester.h"
 
-using std::string;
-using std::string_view;
-using std::size_t;
-
 //must be defined in a unit-specific source file such as "array-test.cpp"
 void runTests();
 
@@ -44,6 +40,11 @@ int main(int argc, char* argv[])
 
 void processCmdLine(char* arguments[], const std::size_t size)
 {
+   using std::string;
+   using std::string_view;
+   using std::size_t;
+   
+   //default values for cmd-line option names in name-value pairs
    bool printHeader{ true };
    bool printSummary{ true };
    string headerText("Running $exe");
@@ -52,12 +53,16 @@ void processCmdLine(char* arguments[], const std::size_t size)
    string_view fileOpenMode;
    string outputFilename;
 
+   //names in name-value pair for cmd-line options
    constexpr string_view option_name_header{ "-h" }, option_name_header_text{ "-ht" },
       option_name_summary{ "-s" }, option_name_prm{ "-p" }, option_name_file{ "-f" },
       option_name_file_overwrite{ "-fo" }, option_name_file_append{ "-fa" },
       option_name_threshold{ "-t" };
 
+   //values in name-value pair for boolean cmd-line options
    constexpr string_view option_value_yes{ "yes" };
+
+   //values for prm option name
    constexpr string_view option_value_detail{ "detail" },
       option_value_indicate{ "indicate" }, option_value_none{ "none" },
       option_value_auto{ "auto" };
@@ -65,25 +70,25 @@ void processCmdLine(char* arguments[], const std::size_t size)
    //begin parsing cmd-line arguments
    for (size_t i = 1; i < size; i += 2)
    {
-      string_view option_name(arguments[i]), value(arguments[i + 1]);
+      string_view name(arguments[i]), value(arguments[i + 1]);
       
-      if (option_name == option_name_header)
+      if (name == option_name_header)
          printHeader = (value == option_value_yes);
-      else if (option_name == option_name_header_text)
+      else if (name == option_name_header_text)
          headerText = value;
-      else if (option_name == option_name_prm)
+      else if (name == option_name_prm)
          passReportMode = value;
-      else if (option_name == option_name_summary)
+      else if (name == option_name_summary)
          printSummary = (value == option_value_yes);
-      else if (option_name == option_name_threshold)
+      else if (name == option_name_threshold)
       {
          std::from_chars(value.data(), value.data() + value.size(), failThreshold);
          setFailThreshold(failThreshold);
       }
-      else if (option_name == option_name_file || option_name == option_name_file_overwrite ||
-         option_name == option_name_file_append)
+      else if (name == option_name_file || name == option_name_file_overwrite ||
+         name == option_name_file_append)
       {
-         fileOpenMode = option_name;
+         fileOpenMode = name;
          outputFilename = value;
       }
    } //done parsing cmd-line arguments
@@ -113,9 +118,7 @@ void processCmdLine(char* arguments[], const std::size_t size)
    //and the print header option is enabled
    const string exeMacro{ "$exe" };
    if (printHeader && !headerText.empty())
-   {
       replace_all(headerText, exeMacro, filenameNoExt);
-   }
    else
       headerText = "";
 
@@ -123,9 +126,7 @@ void processCmdLine(char* arguments[], const std::size_t size)
 
    //if a filename was supplied, replace $exe macro in filename
    if (!outputFilename.empty())
-   {
       replace_all(outputFilename, exeMacro, filenameNoExt);
-   }
 
    //the file stream must be alive when runTests() is called
    std::ofstream fileOut;

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -83,7 +83,7 @@ void processCmdLine(std::vector<std::string_view> arguments)
        setPassReportMode(passReportMode::none);
    else if (passReportMode == "auto")
    {
-      if (fileOpenMode.empty())
+      if (!fileOpenMode.empty())
          setPassReportMode(passReportMode::none);
       else
          setPassReportMode(passReportMode::indicate);
@@ -94,7 +94,7 @@ void processCmdLine(std::vector<std::string_view> arguments)
    std::filesystem::path exePath(arguments[0]);
    std::string filenameNoExtension = exePath.replace_extension("").filename().string();
 
-   //replace $exe macro in header text and file name
+   //replace $exe macro in header text
    if (printHeader && !headerText.empty())
    {
       std::string::size_type macroPosition = headerText.find("$exe");
@@ -106,6 +106,7 @@ void processCmdLine(std::vector<std::string_view> arguments)
 
    setHeaderText(headerText);
 
+   //replace $exe macro in filename
    if (!outputFilename.empty())
    {
       std::string::size_type macroPosition = outputFilename.find("$exe");

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -154,13 +154,12 @@ void processCmdLine(char* arguments[], const std::size_t size)
       summarizeTests();
 }
 
-//Replace all instances of a substring with a different substring
-void replace_all(std::string& str, const std::string& substr, 
-   const std::string& new_substr)
+//replace all instances of a substring with a new substring
+void replace_all(std::string& str, const std::string& substr, const std::string& new_substr)
 {
-  auto pos = str.find(substr);
-  auto substr_size = substr.size();
-   for (; pos != std::string::npos; pos = str.find(substr, pos + substr_size))
+   auto pos = str.find(substr);
+   auto substr_size = substr.size(), new_substr_size = new_substr.size();
+   for (; pos != std::string::npos; pos = str.find(substr, pos + new_substr_size))
       str.replace(pos, substr_size, new_substr);
 }
 

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -158,7 +158,7 @@ void processCmdLine(const std::vector<string_view>& arguments)
    }
    catch (const std::string & msg)
    {
-      std::cout << msg << '\n'; //TODO: print in appropriate stream based in cmd-line
+      (outputFilename.empty() ? std::cout : fileOut )<< msg << '\n';
    }
 
    //if print summary option is enabled

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -32,8 +32,8 @@ void runTests();
 
 void processCmdLine(char* arguments[], const size_t size);
 
-void replace_all(string& str, const string& substr, 
-   const string& toReplace);
+void replace_all(std::string& str, const std::string& substr, 
+   const std::string& new_substr);
 
 int main(int argc, char* argv[])
 {

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -15,8 +15,6 @@
 #include <fstream>
 #include <filesystem>
 #include <charconv>
-#include <array>
-#include <vector>
 #include <string>
 #include <string_view>
 #include <cstddef>

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -32,7 +32,7 @@ void runTests();
 
 void processCmdLine(char* arguments[], const size_t size);
 
-void replace_all(string& str, const string_view substr, 
+void replace_all(string& str, const string& substr, 
    const string& toReplace);
 
 int main(int argc, char* argv[])
@@ -42,13 +42,11 @@ int main(int argc, char* argv[])
    return getTestsFailed();
 }
 
-static const string defaultHeaderText("Running $exe");
-
 void processCmdLine(char* arguments[], const size_t size)
 {
    bool printHeader{ true };
    bool printSummary{ true };
-   string headerText(defaultHeaderText);
+   string headerText("Running $exe");
    string_view passReportMode("auto");
    unsigned short failThreshold(0);
    string_view fileOpenMode;
@@ -63,7 +61,7 @@ void processCmdLine(char* arguments[], const size_t size)
    constexpr string_view value_detail{ "detail" },
       value_indicate{ "indicate" }, value_none{ "none" }, value_auto{ "auto" };
 
-   // begin parsing cmd-line arguments
+   //begin parsing cmd-line arguments
    for (size_t i = 1; i < size; i += 2)
    {
       string_view name(arguments[i]), value(arguments[i + 1]);
@@ -113,7 +111,7 @@ void processCmdLine(char* arguments[], const size_t size)
 
    //replace $exe macro in header text only if a header text was defined
    //and the print header option is enabled
-   constexpr string_view exeMacro{ "$exe" };
+   const string exeMacro{ "$exe" };
    if (printHeader && !headerText.empty())
    {
       replace_all(headerText, exeMacro, filenameNoExt);
@@ -129,7 +127,7 @@ void processCmdLine(char* arguments[], const size_t size)
       replace_all(outputFilename, exeMacro, filenameNoExt);
    }
 
-   // the file stream must be alive when runTests() is called
+   //the file stream must be alive when runTests() is called
    std::ofstream fileOut;
    //if output to file option not enabled, use standard output
    if (outputFilename.empty())
@@ -174,10 +172,10 @@ void processCmdLine(char* arguments[], const size_t size)
 }
 
 //Replace all instances of a substring with a different substring
-void replace_all(string& str, const string_view substr, 
-   const string& toReplace)
+void replace_all(string& str, const string& substr, 
+   const string& new_substr)
 {
    string::size_type pos = str.find(substr);
-   for (; pos != string::npos; pos = str.find(substr))
-      str.replace(pos, 4, toReplace);
+   for (; pos != string::npos; pos = str.find(substr, pos + substr.size()))
+      str.replace(pos, 4, new_substr);
 }

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -172,10 +172,11 @@ void processCmdLine(char* arguments[], const size_t size)
 }
 
 //Replace all instances of a substring with a different substring
-void replace_all(string& str, const string& substr, 
-   const string& new_substr)
+void replace_all(std::string& str, std::const string& substr, 
+   const std::string& new_substr)
 {
-   string::size_type pos = str.find(substr);
-   for (; pos != string::npos; pos = str.find(substr, pos + substr.size()))
-      str.replace(pos, 4, new_substr);
+  auto pos = str.find(substr);
+  auto substr_size = substr.size();
+   for (; pos != std::string::npos; pos = str.find(substr, pos + substr_size))
+      str.replace(pos, substr_size, new_substr);
 }

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
    return getTestsFailed();
 }
 
-void processCmdLine(char* arguments[], const size_t size)
+void processCmdLine(char* arguments[], const std::size_t size)
 {
    bool printHeader{ true };
    bool printSummary{ true };


### PR DESCRIPTION
The commits in the PR add command-line support for the test driver. They also make a few related changes to the testing infrastructure (`tester.cpp`). 

The code to process cmd-line args and configure the tester does **not** test for errors. That is, the changes work only if the cmd-line options are specified the way they should be according to [requirements](https://github.com/sigcpp/stl-lite/wiki/Command-line-interface-for-the-test-driver). Error-handling and other special circumstances will be addressed in another PR.

Even though this PR merges relatively small number of changes from `add-cmd-line-nominal` branch to `add-cmd-line` branch, please review as if the changes in this PR and the changes in `add-cmd-line` are both being merged into `dev`. The reason for this approach is to keep `add-cmd-line` branch active for error-handling etc.

Changes to `driver.cpp` (renamed from `main.cpp`):
* Return the number of tests failed as the value of function `main`
* Process cmd-line arguments and configure the tester 

Changes to `tester.cpp`:

* Add function `getTestsFailed`
* Add function `setOutput`