### PR TITLE
Add exception handling to cmd-line processing

### DIFF
--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
 		return -3;
 	}
 	catch (...) {
-		show_error("Unexpected and untyped error");
+		show_error("Unexpected error");
 		return -4;
 	}
 
@@ -90,14 +90,15 @@ static void show_error(const char* message)
 
 static void show_usage(const char* program_path)
 {
-	std::cout << "Usage: ";
-	std::cout << std::filesystem::path{ program_path }.filename().string();
-	std::cout << " {option_name option_value}\n\n";
+	std::string program_filename = std::filesystem::path{ program_path }.filename().string();
+	
+	std::cout << "Usage: " << program_filename << " {option_name option_value}\n\n";
 
 	std::cout <<
 		"  * Options are specified as name-value pairs, with at least one space between name and value.\n"
 		"  * Every option name begins with a - (hyphen), and every option name should have a value.\n"
-		"  * Any number of options may be specified. If an option repeats, the latest occurrence is used.\n";
+		"  * Any number of options may be specified. If an option repeats, the latest occurrence is used.\n"
+		"\n";
 
 	std::cout <<
 		"\nThe following options are available. "
@@ -107,11 +108,17 @@ static void show_usage(const char* program_path)
 		"  -h  <yes, no>\n"
 		"  -ht <header text>\n"
 		"  -s  <yes, no>\n"
-		"  -p  <none, indicate, detail>\n"
+		"  -p  <detail, indicate, none, auto>\n"
 		"  -t  <fail threshold>\n"
 		"  -fn <output file path>\n"
 		"  -fo <output file path>\n"
-		"  -fa <output file path>\n";
+		"  -fa <output file path>\n"
+		"\n";
+
+	std::cout <<
+		"Example usages:\n"
+		<< "  " << program_filename << " -p indicate -fn results.txt\n"
+		<< "  " << program_filename << " -h no -p none -s no\n";
 
 	std::cout <<
 		"\nFull documentation at:\n"

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -14,19 +14,49 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <exception>
 
 #include "tester.h"
 #include "options.h"
+#include "options-exceptions.h"
 
 //must be defined in a unit-specific source file such as "array-test.cpp"
 void runTests();
 
+void show_error(const char* message);
+void show_usage();
+void show_error_and_usage(const char* message);
+
 int main(int argc, char* argv[])
 {
-	Options options = get_options(argv, argc);
-
+	Options options;
 	std::ofstream fileOut;
-	apply_options(options, fileOut);
+
+	try {
+		options = get_options(argv, argc);
+		apply_options(options, fileOut);
+	}
+	catch (const cmd_line_error& cle) {
+		show_error_and_usage(cle.what());
+		return -1;
+	}
+	catch (const std::exception& e) {
+		show_error(e.what());
+		return -2;
+	}
+	catch (const std::string& s) {
+		show_error(std::string("unexpected error: " + s).data());
+		return -3;
+	}
+	catch (const char* z) {
+		show_error((std::string("unexpected error: ") + z).data());
+		return -4;
+	}
+	catch (...) {
+		show_error("Unexpected and untyped error");
+		return -5;
+	}
+
 
 	try {
 		runTests();
@@ -39,4 +69,24 @@ int main(int argc, char* argv[])
 		summarizeTests();
 
 	return getTestsFailed();
+}
+
+
+void show_error_and_usage(const char* message)
+{
+	show_error(message);
+	std::cout << '\n';
+	show_usage();
+}
+
+
+void show_error(const char* message)
+{
+	std::cout << message << '\n';
+}
+
+
+void show_usage()
+{
+	std::cout << "array-test.exe -h yes/no -ht <header text>" << '\n';
 }

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
 		return -2;
 	}
 	catch (const std::exception& e) {
-		show_error((std::string{ "Unexpected error: " } + e.what()).data());
+		show_error((std::string{ "Unexpected error: " } +e.what()).data());
 		return -3;
 	}
 	catch (...) {
@@ -91,18 +91,17 @@ static void show_error(const char* message)
 static void show_usage(const char* program_path)
 {
 	std::string program_filename = std::filesystem::path{ program_path }.filename().string();
-	
+
 	std::cout << "Usage: " << program_filename << " {option_name option_value}\n\n";
 
 	std::cout <<
 		"  * Options are specified as name-value pairs, with at least one space between name and value.\n"
 		"  * Every option name begins with a - (hyphen), and every option name should have a value.\n"
-		"  * Any number of options may be specified. If an option repeats, the latest occurrence is used.\n"
-		"\n";
+		"  * Any number of options may be specified. If an option repeats, the latest occurrence is used.\n";
 
 	std::cout <<
 		"\nThe following options are available. "
-		"Angle brackets are placeholders for option values.\n\n";
+		"Angle brackets are placeholders for option values:\n\n";
 
 	std::cout <<
 		"  -h  <yes, no>\n"

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -40,21 +40,17 @@ int main(int argc, char* argv[])
 		show_error_and_usage(cle.what());
 		return -1;
 	}
-	catch (const std::exception& e) {
-		show_error(e.what());
+	catch (const output_file_error& fe) {
+		show_error_and_usage(fe.what());
 		return -2;
 	}
-	catch (const std::string& s) {
-		show_error(std::string("unexpected error: " + s).data());
+	catch (const std::exception& e) {
+		show_error((std::string("Unexpected error: ") + e.what()).data());
 		return -3;
-	}
-	catch (const char* z) {
-		show_error((std::string("unexpected error: ") + z).data());
-		return -4;
 	}
 	catch (...) {
 		show_error("Unexpected and untyped error");
-		return -5;
+		return -4;
 	}
 
 

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -88,7 +88,7 @@ void show_usage()
 {
 	std::cout << "usage: [command <option>]" << '\n'
 		<< "       [-h <yes, no>] [-ht <header text>] [-p <none, indicate, detail>]" << '\n'
-		<< "       [-s <yes, no>] [-t <number of failed tests to tolerate>] [-f <output file name>]" << '\n'
+		<< "       [-s <yes, no>] [-t <number of failed tests to tolerate>] [-fn <output file name>]" << '\n'
 		<< "       [-fo <file name>] [-fa <file name>] ......" << '\n'
 		<< "For more details, see "
 		<< "https://github.com/sigcpp/stl-lite/wiki/Command-line-interface-for-the-test-driver#options\n";

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
 		return -2;
 	}
 	catch (const std::exception& e) {
-		show_error((std::string("Unexpected error: ") + e.what()).data());
+		show_error((std::string{ "Unexpected error: " } +e.what()).data());
 		return -3;
 	}
 	catch (...) {

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -84,8 +84,12 @@ void show_error(const char* message)
 }
 
 
-//TODO: show cmd-line format, include a couple of example cmd-lines, show link to docs
 void show_usage()
 {
-	std::cout << "array-test.exe -h yes/no -ht <header text>" << '\n';
+	std::cout << "usage: [command <option>]" << '\n'
+		<< "       [-h <yes, no>] [-ht <header text>] [-p <none, indicate, detail>]" << '\n'
+		<< "       [-s <yes, no>] [-t <number of failed tests to tolerate>] [-f <output file name>]" << '\n'
+		<< "       [-fo <file name>] [-fa <file name>] ......" << '\n'
+		<< "For more details, see "
+		<< "https://github.com/sigcpp/stl-lite/wiki/Command-line-interface-for-the-test-driver#options\n";
 }

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -82,6 +82,7 @@ void show_error(const char* message)
 }
 
 
+//TODO: show cmd-line format, include a couple of example cmd-lines, show link to docs
 void show_usage()
 {
 	std::cout << "array-test.exe -h yes/no -ht <header text>" << '\n';

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -59,6 +59,8 @@ int main(int argc, char* argv[])
 	}
 	catch (const std::string& msg) {
 		logLine(msg.data());
+		if (options.fom == file_open_mode::no_file)
+			show_error(msg.data());
 	}
 
 	if (options.summary)

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[])
 		show_error_and_usage(cle.what());
 		return -1;
 	}
-	catch (const output_file_error& fe) {
+	catch (const file_error& fe) {
 		show_error_and_usage(fe.what());
 		return -2;
 	}

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -1,0 +1,131 @@
+/*
+* options-exceptions.h
+* Sean Murthy
+* (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
+*
+* Attribution and copyright notice must be retained.
+* - Attribution may be augmented to include additional authors
+* - Copyright notice cannot be altered
+* Attribution and copyright info may be relocated but they must be conspicuous.
+*
+* Define options-related exceptions
+*/
+
+#ifndef STL_LITE_OPTIONS_EXCEPTIONS_H
+#define STL_LITE_OPTIONS_EXCEPTIONS_H
+
+#include <stdexcept>
+#include <string_view>
+#include <string>
+#include <filesystem>
+
+static std::string message(const std::string_view& base, const std::string& extra = "")
+{
+	std::string msg{ base };
+	if (!extra.empty())
+		msg += ": " + extra;
+
+	return msg;
+}
+
+//base class for cmd-line errors: no public ctors to force use of a specialized error
+class cmd_line_error : public std::runtime_error {
+
+protected:
+	cmd_line_error(const std::string_view& base) : std::runtime_error(message(base)) {}
+
+	cmd_line_error(const std::string_view& base, const std::string& details) : 
+		std::runtime_error(message(base, details)),
+		details_(details) {}
+
+	const std::string& details() const noexcept
+	{
+		return details_;
+	}
+
+private:
+	std::string details_;
+};
+
+
+//general error with cmd-line
+class invalid_cmd_line : public cmd_line_error {
+
+public:
+	invalid_cmd_line() : cmd_line_error(base) {}
+	invalid_cmd_line(const char* details) : invalid_cmd_line(std::string(details)) {}
+	invalid_cmd_line(const std::string_view& details) : invalid_cmd_line(std::string(details)) {}
+	invalid_cmd_line(const std::string& details) : cmd_line_error(base, details) {}
+
+	const std::string& details() const noexcept
+	{
+		return cmd_line_error::details();
+	}
+
+private:
+	static constexpr std::string_view base{ "invalid command line" };
+};
+
+
+//error with option name on the cmd-line
+class invalid_option_name : public cmd_line_error
+{
+
+public:
+	invalid_option_name() : cmd_line_error(base) {}
+	invalid_option_name(const char* name) : invalid_option_name(std::string(name)) {}
+	invalid_option_name(const std::string_view& name) : invalid_option_name(std::string(name)) {}
+	invalid_option_name(const std::string& name) : cmd_line_error(base, name) {}
+
+	const std::string& option_name() const noexcept
+	{
+		return cmd_line_error::details();
+	}
+
+private:
+	static constexpr std::string_view base{ "invalid option name" };
+};
+
+
+//error with option value on the cmd-line
+class invalid_option_value : public cmd_line_error
+{
+
+public:
+	invalid_option_value() : cmd_line_error(base) {}
+	invalid_option_value(const char* value) : invalid_option_value(std::string(value)) {}
+	invalid_option_value(const std::string_view& value) : invalid_option_value(std::string(value)) {}
+	invalid_option_value(const std::string& value) : cmd_line_error(base, value) {}
+
+	const std::string& option_value() const noexcept
+	{
+		return cmd_line_error::details();
+	}
+
+private:
+	static constexpr std::string_view base { "invalid option value" };
+};
+
+
+//error related to output file
+class output_file_error : public std::runtime_error {
+
+public:
+	output_file_error(const std::string& base) : std::runtime_error(message(base)) {}
+
+	output_file_error(const std::string& base, const std::filesystem::path& filepath) :
+		std::runtime_error(message(base, filepath.string())),
+		filepath_(filepath)
+	{}
+
+	const std::filesystem::path& filepath() const noexcept
+	{
+		return filepath_;
+	}
+
+private:
+	std::filesystem::path filepath_;
+};
+
+
+#endif

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -107,7 +107,7 @@ private:
 };
 
 
-//error related to output file
+//file-related error
 class file_error : public std::runtime_error {
 
 public:
@@ -126,6 +126,5 @@ public:
 private:
 	std::filesystem::path filepath_;
 };
-
 
 #endif

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -122,8 +122,7 @@ public:
 
 	file_error(const std::string& base, const std::filesystem::path& filepath) :
 		std::runtime_error{ message(base, filepath.string()) },
-		filepath_{ filepath }
-	{}
+		filepath_{ filepath } {}
 
 	const std::filesystem::path& filepath() const noexcept
 	{

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -32,11 +32,11 @@ static std::string message(const std::string_view& base, const std::string& extr
 class cmd_line_error : public std::runtime_error {
 
 protected:
-	cmd_line_error(const std::string_view& base) : std::runtime_error(message(base)) {}
+	cmd_line_error(const std::string_view& base) : std::runtime_error{ message(base) } {}
 
 	cmd_line_error(const std::string_view& base, const std::string& details) : 
-		std::runtime_error(message(base, details)),
-		details_(details) {}
+		std::runtime_error{ message(base, details) },
+		details_{ details } {}
 
 	const std::string& details() const noexcept
 	{
@@ -52,10 +52,10 @@ private:
 class invalid_cmd_line : public cmd_line_error {
 
 public:
-	invalid_cmd_line() : cmd_line_error(base) {}
-	invalid_cmd_line(const char* details) : invalid_cmd_line(std::string(details)) {}
-	invalid_cmd_line(const std::string_view& details) : invalid_cmd_line(std::string(details)) {}
-	invalid_cmd_line(const std::string& details) : cmd_line_error(base, details) {}
+	invalid_cmd_line() : cmd_line_error{base} {}
+	invalid_cmd_line(const char* details) : invalid_cmd_line{ std::string{details} } {}
+	invalid_cmd_line(const std::string_view& details) : invalid_cmd_line{ std::string{details} } {}
+	invalid_cmd_line(const std::string& details) : cmd_line_error{ base, details } {}
 
 	const std::string& details() const noexcept
 	{
@@ -72,10 +72,10 @@ class invalid_option_name : public cmd_line_error
 {
 
 public:
-	invalid_option_name() : cmd_line_error(base) {}
-	invalid_option_name(const char* name) : invalid_option_name(std::string(name)) {}
-	invalid_option_name(const std::string_view& name) : invalid_option_name(std::string(name)) {}
-	invalid_option_name(const std::string& name) : cmd_line_error(base, name) {}
+	invalid_option_name() : cmd_line_error{base} {}
+	invalid_option_name(const char* name) : invalid_option_name{ std::string{name} } {}
+	invalid_option_name(const std::string_view& name) : invalid_option_name{ std::string{name} } {}
+	invalid_option_name(const std::string& name) : cmd_line_error{ base, name } {}
 
 	const std::string& option_name() const noexcept
 	{
@@ -92,10 +92,10 @@ class invalid_option_value : public cmd_line_error
 {
 
 public:
-	invalid_option_value() : cmd_line_error(base) {}
-	invalid_option_value(const char* value) : invalid_option_value(std::string(value)) {}
-	invalid_option_value(const std::string_view& value) : invalid_option_value(std::string(value)) {}
-	invalid_option_value(const std::string& value) : cmd_line_error(base, value) {}
+	invalid_option_value() : cmd_line_error{base} {}
+	invalid_option_value(const char* value) : invalid_option_value{ std::string{value} } {}
+	invalid_option_value(const std::string_view& value) : invalid_option_value{ std::string{value} } {}
+	invalid_option_value(const std::string& value) : cmd_line_error{ base, value } {}
 
 	const std::string& option_value() const noexcept
 	{
@@ -111,11 +111,11 @@ private:
 class file_error : public std::runtime_error {
 
 public:
-	file_error(const std::string& base) : std::runtime_error(message(base)) {}
+	file_error(const std::string& base) : std::runtime_error{ message(base) } {}
 
 	file_error(const std::string& base, const std::filesystem::path& filepath) :
-		std::runtime_error(message(base, filepath.string())),
-		filepath_(filepath)
+		std::runtime_error{ message(base, filepath.string()) },
+		filepath_{ filepath }
 	{}
 
 	const std::filesystem::path& filepath() const noexcept

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -34,7 +34,7 @@ class cmd_line_error : public std::runtime_error {
 protected:
 	cmd_line_error(const std::string_view& base) : std::runtime_error{ message(base) } {}
 
-	cmd_line_error(const std::string_view& base, const std::string& details) : 
+	cmd_line_error(const std::string_view& base, const std::string& details) :
 		std::runtime_error{ message(base, details) },
 		details_{ details } {}
 
@@ -52,7 +52,7 @@ private:
 class invalid_cmd_line : public cmd_line_error {
 
 public:
-	invalid_cmd_line() : cmd_line_error{base} {}
+	invalid_cmd_line() : cmd_line_error{ base } {}
 	invalid_cmd_line(const char* details) : invalid_cmd_line{ std::string{details} } {}
 	invalid_cmd_line(const std::string_view& details) : invalid_cmd_line{ std::string{details} } {}
 	invalid_cmd_line(const std::string& details) : cmd_line_error{ base, details } {}
@@ -68,11 +68,10 @@ private:
 
 
 //error with option name on the cmd-line
-class invalid_option_name : public cmd_line_error
-{
+class invalid_option_name : public cmd_line_error {
 
 public:
-	invalid_option_name() : cmd_line_error{base} {}
+	invalid_option_name() : cmd_line_error{ base } {}
 	invalid_option_name(const char* name) : invalid_option_name{ std::string{name} } {}
 	invalid_option_name(const std::string_view& name) : invalid_option_name{ std::string{name} } {}
 	invalid_option_name(const std::string& name) : cmd_line_error{ base, name } {}
@@ -88,11 +87,10 @@ private:
 
 
 //error with option value on the cmd-line
-class invalid_option_value : public cmd_line_error
-{
+class invalid_option_value : public cmd_line_error {
 
 public:
-	invalid_option_value() : cmd_line_error{base} {}
+	invalid_option_value() : cmd_line_error{ base } {}
 	invalid_option_value(const char* value) : invalid_option_value{ std::string{value} } {}
 	invalid_option_value(const std::string_view& value) : invalid_option_value{ std::string{value} } {}
 	invalid_option_value(const std::string& value) : cmd_line_error{ base, value } {}
@@ -103,7 +101,7 @@ public:
 	}
 
 private:
-	static constexpr std::string_view base { "invalid option value" };
+	static constexpr std::string_view base{ "invalid option value" };
 };
 
 

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -53,8 +53,11 @@ class invalid_cmd_line : public cmd_line_error {
 
 public:
 	invalid_cmd_line() : cmd_line_error{ base } {}
+
 	invalid_cmd_line(const char* details) : invalid_cmd_line{ std::string{details} } {}
+
 	invalid_cmd_line(const std::string_view& details) : invalid_cmd_line{ std::string{details} } {}
+
 	invalid_cmd_line(const std::string& details) : cmd_line_error{ base, details } {}
 
 	const std::string& details() const noexcept
@@ -72,8 +75,11 @@ class invalid_option_name : public cmd_line_error {
 
 public:
 	invalid_option_name() : cmd_line_error{ base } {}
+
 	invalid_option_name(const char* name) : invalid_option_name{ std::string{name} } {}
+
 	invalid_option_name(const std::string_view& name) : invalid_option_name{ std::string{name} } {}
+
 	invalid_option_name(const std::string& name) : cmd_line_error{ base, name } {}
 
 	const std::string& option_name() const noexcept
@@ -91,8 +97,11 @@ class invalid_option_value : public cmd_line_error {
 
 public:
 	invalid_option_value() : cmd_line_error{ base } {}
+
 	invalid_option_value(const char* value) : invalid_option_value{ std::string{value} } {}
+
 	invalid_option_value(const std::string_view& value) : invalid_option_value{ std::string{value} } {}
+
 	invalid_option_value(const std::string& value) : cmd_line_error{ base, value } {}
 
 	const std::string& option_value() const noexcept

--- a/test/options-exceptions.h
+++ b/test/options-exceptions.h
@@ -108,12 +108,12 @@ private:
 
 
 //error related to output file
-class output_file_error : public std::runtime_error {
+class file_error : public std::runtime_error {
 
 public:
-	output_file_error(const std::string& base) : std::runtime_error(message(base)) {}
+	file_error(const std::string& base) : std::runtime_error(message(base)) {}
 
-	output_file_error(const std::string& base, const std::filesystem::path& filepath) :
+	file_error(const std::string& base, const std::filesystem::path& filepath) :
 		std::runtime_error(message(base, filepath.string())),
 		filepath_(filepath)
 	{}

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -202,6 +202,8 @@ bool strtobool(const std::string_view& value)
 }
 
 
+//convert text to whole number: reject negative values, out of range values, and text with invalid chars
+//assumes base 10
 //assumes parameter is not empty (caller will have already checked that)
 unsigned short get_fail_threshold(const std::string_view& sv)
 {

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -8,7 +8,7 @@
 * - Copyright notice cannot be altered
 * Attribution and copyright info may be relocated but they must be conspicuous.
 *
-* Tester options
+* Cmd-line options
 */
 
 #include <iostream>
@@ -69,7 +69,7 @@ Options get_options(char* arguments[], const std::size_t size)
 		else if (value.empty())
 			throw invalid_option_value{ "empty option value" };
 		else if (name[0] != '-')
-			throw invalid_option_name{ std::string{ name } };
+			throw invalid_option_name{ name };
 
 		if (name == option_name_header)
 			options.header = strtobool(value);

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -31,19 +31,19 @@ Options get_options(char* arguments[], const std::size_t size)
 	assert(size % 2 == 1);
 
 	if (size == 0)
-		throw invalid_cmd_line("empty command line");
+		throw invalid_cmd_line{ "empty command line" };
 
 	if (size % 2 == 0)
-		throw invalid_cmd_line("incorrect number of options");
+		throw invalid_cmd_line{ "incorrect number of options" };
 
 	Options options;
 
 	//extract "command name" from first arg: command name is just command filename without path or extension
 	//command file path cannot be empty
-	std::filesystem::path command_path = arguments[0];
+	std::filesystem::path command_path{ arguments[0] };
 	assert(!command_path.empty());
 	if (command_path.empty())
-		throw invalid_cmd_line("missing command filepath");
+		throw invalid_cmd_line{ "missing command filepath" };
 
 	options.command_name = command_path.replace_extension("").filename().string();
 
@@ -57,7 +57,7 @@ Options get_options(char* arguments[], const std::size_t size)
 
 	//begin parsing arguments from index 1 because args[0] corresponds to command name
 	for (std::size_t i = 1; i < size; i += 2) {
-		std::string_view name(arguments[i]), value(arguments[i + 1]);
+		std::string_view name{ arguments[i] }, value{ arguments[i + 1] };
 		
 		//option name or value cannot be empty; options names must begin with a - 
 		assert(!name.empty());
@@ -65,11 +65,11 @@ Options get_options(char* arguments[], const std::size_t size)
 		assert(name[0] == '-');
 
 		if (name.empty())
-			throw invalid_option_name("empty option name");
+			throw invalid_option_name{ "empty option name" };
 		else if (value.empty())
-			throw invalid_option_value("empty option value");
+			throw invalid_option_value{ "empty option value" };
 		else if (name[0] != '-')
-			throw invalid_option_name(std::string(name));
+			throw invalid_option_name{ std::string{ name } };
 
 		if (name == option_name_header)
 			options.header = strtobool(value);
@@ -87,7 +87,7 @@ Options get_options(char* arguments[], const std::size_t size)
 		}
 		else { //unknown option
 			assert(false);
-			throw invalid_option_name(name);
+			throw invalid_option_name{ name };
 		}
 	}
 
@@ -129,7 +129,7 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 		//enforce create-only file open mode
 		if (options.fom == file_open_mode::new_file && std::filesystem::exists(options.output_filepath)) {
 			assert(false);
-			throw file_error("Output file already exists", options.output_filepath);
+			throw file_error{ "Output file already exists", options.output_filepath };
 		}
 
 		//open file in append mode or overwrite mode: create-only mode has already been checked
@@ -138,7 +138,7 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 
 		if (!fileOut.is_open()) {
 			assert(false);
-			throw file_error("Error opening output file", options.output_filepath);
+			throw file_error{ "Error opening output file", options.output_filepath };
 		}
 	}
 }
@@ -162,7 +162,7 @@ pass_report_mode get_pass_report_mode(const std::string_view& value, file_open_m
 		return fom == file_open_mode::no_file ? pass_report_mode::indicate : pass_report_mode::none;
 	else {
 		assert(false);
-		throw invalid_option_value(value);
+		throw invalid_option_value{ value };
 	}
 }
 
@@ -180,7 +180,7 @@ file_open_mode get_file_open_mode(const std::string_view& name)
 		return file_open_mode::append;
 	else {
 		assert(false);
-		throw invalid_option_name(name);
+		throw invalid_option_name{ name };
 	}
 }
 
@@ -196,7 +196,7 @@ bool strtobool(const std::string_view& value)
 		return false;
 	else {
 		assert(false);
-		throw invalid_option_value(value);
+		throw invalid_option_value{ value };
 	}
 }
 

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -97,7 +97,7 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 		setOutput(fileOut);
 
 		//enforce create-only file open mode
-		if (options.fom == file_open_mode::create && std::filesystem::exists(options.output_filepath)) {
+		if (options.fom == file_open_mode::new_file && std::filesystem::exists(options.output_filepath)) {
 			std::cerr << "Output file already exists";
 			return;
 		}
@@ -145,7 +145,7 @@ file_open_mode get_file_open_mode(const std::string_view& name)
 		option_name_file_append("-fa");
 
 	if (name == option_name_file)
-		return file_open_mode::create;
+		return file_open_mode::new_file;
 	if (name == option_name_file_overwrite)
 		return file_open_mode::overwrite;
 	if (name == option_name_file_append)

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -34,9 +34,18 @@ Options get_options(char* arguments[], const std::size_t size)
 		throw invalid_cmd_line("empty command line");
 
 	if (size % 2 == 0)
-		throw invalid_cmd_line("invalid number of options");
+		throw invalid_cmd_line("incorrect number of options");
 
 	Options options;
+
+	//extract "command name" from first arg: command name is just command filename without path or extension
+	//command file path cannot be empty
+	std::filesystem::path command_path = arguments[0];
+	assert(!command_path.empty());
+	if (command_path.empty())
+		throw invalid_cmd_line("missing command filepath");
+
+	options.command_name = command_path.replace_extension("").filename().string();
 
 	//names in name-value pair for cmd-line options
 	constexpr std::string_view option_name_header{ "-h" }, option_name_header_text{ "-ht" },
@@ -50,7 +59,7 @@ Options get_options(char* arguments[], const std::size_t size)
 	for (std::size_t i = 1; i < size; i += 2) {
 		std::string_view name(arguments[i]), value(arguments[i + 1]);
 		
-		//option name or value cannot be empty; options names begin with a - 
+		//option name or value cannot be empty; options names must begin with a - 
 		assert(!name.empty());
 		assert(!value.empty());
 		assert(name[0] == '-');
@@ -83,16 +92,6 @@ Options get_options(char* arguments[], const std::size_t size)
 	}
 
 	options.prm = get_pass_report_mode(prm_value, options.fom);
-
-	//extract "command name" from first arg: command name is just command filename without path or extension
-	//command file path cannot be empty
-	std::filesystem::path command_path = arguments[0];
-
-	assert(!command_path.empty());
-	if (command_path.empty())
-		throw invalid_cmd_line("missing command filepath");
-
-	options.command_name = command_path.replace_extension("").filename().string();
 
 	//replace $cmd macro with command name in header text
 	const std::string cmd_macro{ "$cmd" };

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -130,7 +130,7 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 		//enforce create-only file open mode
 		if (options.fom == file_open_mode::new_file && std::filesystem::exists(options.output_filepath)) {
 			assert(false);
-			throw output_file_error("Output file already exists", options.output_filepath);
+			throw file_error("Output file already exists", options.output_filepath);
 		}
 
 		//open file in append mode or overwrite mode: create-only mode has already been checked
@@ -139,7 +139,7 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 
 		if (!fileOut.is_open()) {
 			assert(false);
-			throw output_file_error("Error opening output file", options.output_filepath);
+			throw file_error("Error opening output file", options.output_filepath);
 		}
 	}
 }

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -24,7 +24,7 @@
 
 Options get_options(char* arguments[], const std::size_t size)
 {
-	//args cannot be empty: args[0] expected to be "command name" (path to executable file)
+	//args should not be empty: args[0] should be path to executable file
 	assert(size != 0);
 
 	Options options;
@@ -64,7 +64,7 @@ Options get_options(char* arguments[], const std::size_t size)
 	options.command_name = exePath.replace_extension("").filename().string();
 
 	//replace $exe macro with command name in header text
-	const std::string exeMacro{ "$exe" };
+	const std::string exeMacro{ "$cmd" };
 	if (options.header && !options.header_text.empty())
 		replace_all(options.header_text, exeMacro, options.command_name);
 	else

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -21,11 +21,20 @@
 #include <cassert>
 
 #include "options.h"
+#include "options-exceptions.h"
 
 Options get_options(char* arguments[], const std::size_t size)
 {
-	//args should not be empty: args[0] should be path to executable file
+	//args should not be empty: args[0] should be path to executable file ("command name")
+	//number of args should be odd: command name followed by name-value pairs for options
 	assert(size != 0);
+	assert(size % 2 == 1);
+
+	if (size == 0)
+		throw invalid_cmd_line("empty command line");
+
+	if (size % 2 == 0)
+		throw invalid_cmd_line("invalid number of options");
 
 	Options options;
 
@@ -40,6 +49,18 @@ Options get_options(char* arguments[], const std::size_t size)
 	//begin parsing arguments from index 1 because args[0] corresponds to command name
 	for (std::size_t i = 1; i < size; i += 2) {
 		std::string_view name(arguments[i]), value(arguments[i + 1]);
+		
+		//option name or value cannot be empty; options names begin with a - 
+		assert(!name.empty());
+		assert(!value.empty());
+		assert(name[0] == '-');
+
+		if (name.empty())
+			throw invalid_option_name("empty option name");
+		else if (value.empty())
+			throw invalid_option_value("empty option value");
+		else if (name[0] != '-')
+			throw invalid_option_name(std::string(name));
 
 		if (name == option_name_header)
 			options.header = strtobool(value);
@@ -55,24 +76,34 @@ Options get_options(char* arguments[], const std::size_t size)
 			options.fom = get_file_open_mode(name);
 			output_filepath_value = value;
 		}
+		else { //unknown option
+			assert(false);
+			throw invalid_option_name(name);
+		}
 	}
 
 	options.prm = get_pass_report_mode(prm_value, options.fom);
 
-	//extract "command name" from first arg: command name is just exe filename without path or extension
-	std::filesystem::path exePath = arguments[0];
-	options.command_name = exePath.replace_extension("").filename().string();
+	//extract "command name" from first arg: command name is just command filename without path or extension
+	//command file path cannot be empty
+	std::filesystem::path command_path = arguments[0];
 
-	//replace $exe macro with command name in header text
-	const std::string exeMacro{ "$cmd" };
+	assert(!command_path.empty());
+	if (command_path.empty())
+		throw invalid_cmd_line("missing command filepath");
+
+	options.command_name = command_path.replace_extension("").filename().string();
+
+	//replace $cmd macro with command name in header text
+	const std::string cmd_macro{ "$cmd" };
 	if (options.header && !options.header_text.empty())
-		replace_all(options.header_text, exeMacro, options.command_name);
+		replace_all(options.header_text, cmd_macro, options.command_name);
 	else
 		options.header_text = "";
 
-	//replace $exe macro in output file path; also set file extension to ".out" if extension missing
+	//replace $cmd macro in output file path; also set file extension to ".out" if extension missing
 	if (options.fom != file_open_mode::no_file) {
-		replace_all(output_filepath_value, exeMacro, options.command_name);
+		replace_all(output_filepath_value, cmd_macro, options.command_name);
 
 		options.output_filepath = output_filepath_value;
 		if (options.output_filepath.extension().empty())
@@ -98,8 +129,8 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 
 		//enforce create-only file open mode
 		if (options.fom == file_open_mode::new_file && std::filesystem::exists(options.output_filepath)) {
-			std::cerr << "Output file already exists";
-			return;
+			assert(false);
+			throw output_file_error("Output file already exists", options.output_filepath);
 		}
 
 		//open file in append mode or overwrite mode: create-only mode has already been checked
@@ -107,8 +138,8 @@ void apply_options(const Options& options, std::ofstream& fileOut)
 		fileOut.open(options.output_filepath, options.fom == file_open_mode::append ? ios::app : ios::out);
 
 		if (!fileOut.is_open()) {
-			std::cerr << "Error opening output file";
-			return;
+			assert(false);
+			throw output_file_error("Error opening output file", options.output_filepath);
 		}
 	}
 }
@@ -132,9 +163,7 @@ pass_report_mode get_pass_report_mode(const std::string_view& value, file_open_m
 		return fom == file_open_mode::no_file ? pass_report_mode::indicate : pass_report_mode::none;
 	else {
 		assert(false);
-
-		//TO DO: review exception mgmt in the entire file; using temp value for now
-		throw "invalid value for pass report mode";
+		throw invalid_option_value(value);
 	}
 }
 
@@ -152,9 +181,7 @@ file_open_mode get_file_open_mode(const std::string_view& name)
 		return file_open_mode::append;
 	else {
 		assert(false);
-
-		//TO DO: review exception mgmt in the entire file; using temp value for now
-		throw "invalid value for file open mode";
+		throw invalid_option_name(name);
 	}
 }
 
@@ -170,9 +197,7 @@ bool strtobool(const std::string_view& value)
 		return false;
 	else {
 		assert(false);
-
-		//TO DO: review exception mgmt in the entire file; using temp value for now
-		throw "invalid value";
+		throw invalid_option_value(value);
 	}
 }
 

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -141,10 +141,10 @@ pass_report_mode get_pass_report_mode(const std::string_view& value, file_open_m
 
 file_open_mode get_file_open_mode(const std::string_view& name)
 {
-	constexpr std::string_view option_name_file("-f"), option_name_file_overwrite("-fo"),
+	constexpr std::string_view option_name_file_new("-fn"), option_name_file_overwrite("-fo"),
 		option_name_file_append("-fa");
 
-	if (name == option_name_file)
+	if (name == option_name_file_new)
 		return file_open_mode::new_file;
 	if (name == option_name_file_overwrite)
 		return file_open_mode::overwrite;

--- a/test/options.h
+++ b/test/options.h
@@ -1,5 +1,5 @@
 /*
-* tester.h
+* options.h
 * Sean Murthy
 * (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
 *
@@ -19,7 +19,7 @@
 
 #include "tester.h"
 
-enum class file_open_mode { no_file, create, overwrite, append };
+enum class file_open_mode { no_file, new_file, overwrite, append };
 
 struct Options {
 	bool header{ true };

--- a/test/options.h
+++ b/test/options.h
@@ -8,7 +8,7 @@
 * - Copyright notice cannot be altered
 * Attribution and copyright info may be relocated but they must be conspicuous.
 *
-* Declare testing infrastructure
+* Declare tester options
 */
 
 #ifndef STL_LITE_OPTIONS_H
@@ -24,7 +24,7 @@ enum class file_open_mode { no_file, new_file, overwrite, append };
 struct Options {
 	bool header{ true };
 	bool summary{ true };
-	std::string header_text{ "Running $exe" };
+	std::string header_text{ "Running $cmd" };
 	pass_report_mode prm{ pass_report_mode::indicate };
 	unsigned short fail_threshold = 0;
 	file_open_mode fom{ file_open_mode::no_file };

--- a/test/test-stl-lite.vcxproj
+++ b/test/test-stl-lite.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="tester.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="options-exceptions.h" />
     <ClInclude Include="options.h" />
     <ClInclude Include="tester.h" />
   </ItemGroup>

--- a/test/test-stl-lite.vcxproj.filters
+++ b/test/test-stl-lite.vcxproj.filters
@@ -35,5 +35,8 @@
     <ClInclude Include="tester.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="options-exceptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The changes in this PR make the following changes/additions to cmd-line processing:

- Change label `create` to `new_file` in enum `file_open_mode`
- Change `-f` option to `-fn`
- Change macro `$exe` to `$cmd` to make the term platform neutral
- Define custom exception classes
- Add assertions and throw exceptions to options management
- Catch exceptions in driver and show error message and usage
- Use UIS throughout the driver and option mgmt code

The following changes are pending and expected to be made as part of this PR:
- Update docs in Wiki to reflect changes in option name and $cmd macro. @Ndemco 
- `get_fail_threshold` needs error checking. **I will work on this tomorrow**.
- `show_usage` needs to be implemented. TODO notes left with the function. Either @Ndemco or @cmcmone will be working on this.

**Please review the changes and opine.**