### PR TITLE
Fix issues assigned to Milestone M5

### DIFF
--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -28,9 +28,11 @@
 
 //error codes returned back from main are negative
 enum class error_code {
-	cmd_line_initial = -1, file_initial = -2, unexpected_typed_initial = -3, unexpected_untyped_initial = -4,
-	cmd_line_run = -6, file_run = -7, suite_add_run = -8, unexpected_typed_run = -9,
-	unexpected_untyped_run = -10
+	no_error = 0,
+	cmd_line_initial = -1, file_initial = -2, 
+	unexpected_typed_initial = -51, unexpected_untyped_initial = -52,
+	cmd_line_run = -100, file_run = -101, suite_add_run = -102, fail_threshold_run = -103,
+	unexpected_typed_run = -151, unexpected_untyped_run = -152
 };
 
 

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 	if (options.summary)
 		summarize_tests();
 
-	//return totaly tests failed only if there was no error: the caller should know if there was an error
+	//return total tests failed only if there was no error: the caller should know if there was an error
 	if (error_code == driver_error_code::no_error)
 		return get_tests_failed_total();
 	else

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -8,7 +8,7 @@
 * - Copyright notice cannot be altered
 * Attribution and copyright info may be relocated but they must be conspicuous.
 *
-* Intialize tester and start unit tests
+* Intialize tester from cmd-line and run unit tests
 */
 
 #include <iostream>

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -40,7 +40,7 @@ enum class driver_error_code {
 	unexpected_typed_options = -51, unexpected_untyped_options = -52,
 
 	//anticipated in run_suites, but before any test is actually run
-	cmd_line_run_suites = -101, test_suite_add = -101,
+	cmd_line_run_suites = -101, test_suite_add = -102,
 
 	//anticipated in run_suites, likely at least one test may have been done
 	file_run_suites = -121, fail_threshold_met = -122,

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -175,7 +175,7 @@ void run_suites(const Options& options)
 
 
 //the following functions assume they are called only from main so that the parameters are always correct
-//assertion and error handling are included by design
+//assertion and error handling are omitted by design
 
 static int show_error_and_usage(const char* message, const char* program_path, driver_error_code ec)
 {

--- a/test/driver.cpp
+++ b/test/driver.cpp
@@ -57,9 +57,9 @@ static void show_usage(const char* program_path);
 static int show_error_and_usage(const char* message, const char* program_path, driver_error_code ec);
 
 
-//return  < 0: error
+//return  < 0: error; including fail threshold met
 //return == 0: no error, no tests failed
-//return  > 0: no error, tests failed; number of failed tests returned
+//return  > 0: no error, some tests failed but fail threshold not met; number of failed tests returned
 int main(int argc, char* argv[])
 {
 	Options options;

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -208,7 +208,7 @@ bool strtobool(const std::string_view& value)
 //convert text to whole number: reject negative values, out of range values, and text with invalid chars
 //assumes base 10
 //assumes parameter is not empty (caller will have already checked that)
-fail_threshold_type get_fail_threshold(const std::string_view& sv)
+int get_fail_threshold(const std::string_view& sv)
 {
 	assert(sv[0] != '-');
 	if (sv[0] == '-')
@@ -216,7 +216,7 @@ fail_threshold_type get_fail_threshold(const std::string_view& sv)
 
 	constexpr std::string_view value_max{ "max" };
 	if (sv == value_max)
-		return max_fail_threshold;
+		return INT_MAX;
 
 	unsigned short value;
 	auto begin = sv.data(), end = begin + sv.size();

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -208,7 +208,7 @@ bool strtobool(const std::string_view& value)
 //convert text to whole number: reject negative values, out of range values, and text with invalid chars
 //assumes base 10
 //assumes parameter is not empty (caller will have already checked that)
-unsigned short get_fail_threshold(const std::string_view& sv)
+fail_threshold_type get_fail_threshold(const std::string_view& sv)
 {
 	assert(sv[0] != '-');
 	if (sv[0] == '-')
@@ -216,7 +216,7 @@ unsigned short get_fail_threshold(const std::string_view& sv)
 
 	constexpr std::string_view value_max{ "max" };
 	if (sv == value_max)
-		return USHRT_MAX;
+		return max_fail_threshold;
 
 	unsigned short value;
 	auto begin = sv.data(), end = begin + sv.size();

--- a/test/options.h
+++ b/test/options.h
@@ -26,7 +26,7 @@ struct Options {
 	bool summary{ true };
 	std::string header_text{ "Running $suite" };
 	pass_report_mode prm{ pass_report_mode::indicate };
-	unsigned short fail_threshold{ 0 };
+	fail_threshold_type fail_threshold{ 0 };
 	file_open_mode fom{ file_open_mode::no_file };
 	std::filesystem::path output_filepath;
 	std::string command_name;
@@ -42,7 +42,7 @@ pass_report_mode get_pass_report_mode(const std::string_view& value, file_open_m
 
 file_open_mode get_file_open_mode(const std::string_view& name);
 
-unsigned short get_fail_threshold(const std::string_view& value);
+fail_threshold_type get_fail_threshold(const std::string_view& value);
 
 bool strtobool(const std::string_view& value);
 

--- a/test/options.h
+++ b/test/options.h
@@ -26,7 +26,7 @@ struct Options {
 	bool summary{ true };
 	std::string header_text{ "Running $suite" };
 	pass_report_mode prm{ pass_report_mode::indicate };
-	fail_threshold_type fail_threshold{ 0 };
+	int fail_threshold{ 0 };
 	file_open_mode fom{ file_open_mode::no_file };
 	std::filesystem::path output_filepath;
 	std::string command_name;
@@ -42,7 +42,7 @@ pass_report_mode get_pass_report_mode(const std::string_view& value, file_open_m
 
 file_open_mode get_file_open_mode(const std::string_view& name);
 
-fail_threshold_type get_fail_threshold(const std::string_view& value);
+int get_fail_threshold(const std::string_view& value);
 
 bool strtobool(const std::string_view& value);
 

--- a/test/test-stl-lite.vcxproj
+++ b/test/test-stl-lite.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="suites.h" />
     <ClInclude Include="tester.h" />
     <ClInclude Include="utils.h" />
+    <ClInclude Include="verifier-exceptions.h" />
     <ClInclude Include="verifiers.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/test-stl-lite.vcxproj.filters
+++ b/test/test-stl-lite.vcxproj.filters
@@ -53,5 +53,8 @@
     <ClInclude Include="suites.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="verifier-exceptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -33,8 +33,8 @@ void set_pass_report_mode(pass_report_mode mode)
 }
 
 
-static unsigned short fail_threshold{ 0 };
-void set_fail_threshold(unsigned short value)
+static fail_threshold_type fail_threshold{ 0 };
+void set_fail_threshold(fail_threshold_type value)
 {
 	fail_threshold = value;
 }
@@ -42,7 +42,7 @@ void set_fail_threshold(unsigned short value)
 
 void set_max_fail_threshold()
 {
-	fail_threshold = USHRT_MAX;
+	fail_threshold = max_fail_threshold;
 }
 
 

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -18,6 +18,8 @@
 
 #include "utils.h"
 #include "tester.h"
+#include "verifier-exceptions.h"
+
 
 static std::string headerText("Running $suite:");
 void set_header_text(std::string text)
@@ -167,8 +169,10 @@ void verify(bool success, const char* hint)
 		message << "Test# " << tests_done_suite << ": FAIL (" << hint << ")\n";
 		last_output_ended_in_linebreak = true;
 
-		if (tests_failed_total > fail_threshold)
-			throw message.str();
+		if (tests_failed_total > fail_threshold) {
+			*pOut << message.str();
+			throw fail_threshold_met_error();
+		}
 	}
 
 	*pOut << message.str();

--- a/test/tester.cpp
+++ b/test/tester.cpp
@@ -35,8 +35,8 @@ void set_pass_report_mode(pass_report_mode mode)
 }
 
 
-static fail_threshold_type fail_threshold{ 0 };
-void set_fail_threshold(fail_threshold_type value)
+static int fail_threshold{ 0 };
+void set_fail_threshold(int value)
 {
 	fail_threshold = value;
 }
@@ -44,7 +44,7 @@ void set_fail_threshold(fail_threshold_type value)
 
 void set_max_fail_threshold()
 {
-	fail_threshold = max_fail_threshold;
+	fail_threshold = INT_MAX;
 }
 
 
@@ -67,12 +67,12 @@ void log_line(const char* s)
 }
 
 
-static unsigned tests_done_total;
-static unsigned tests_done_suite;
-static unsigned tests_failed_total;
-static unsigned tests_failed_suite;
+int tests_done_total;
+int tests_done_suite;
+int tests_failed_total;
+int tests_failed_suite;
 
-unsigned get_tests_failed_total()
+int get_tests_failed_total()
 {
 	return tests_failed_total;
 }

--- a/test/tester.h
+++ b/test/tester.h
@@ -16,25 +16,20 @@
 
 #include <iostream>
 #include <type_traits>
-#include <limits>
 
-
-//type and limit of fail threshold
-using fail_threshold_type = unsigned short;
-static constexpr fail_threshold_type max_fail_threshold{ std::numeric_limits<fail_threshold_type>::max() };
 
 enum class pass_report_mode { none, indicate, detail };
 
 void set_header_text(std::string text);
 void set_pass_report_mode(pass_report_mode mode);
-void set_fail_threshold(fail_threshold_type value);
+void set_fail_threshold(int value);
 void set_max_fail_threshold();
 void set_output(std::ostream& o);
 
 void log(const char* s);
 void log_line(const char* s);
 
-unsigned get_tests_failed_total();
+int get_tests_failed_total();
 
 void start_suite(const std::string& name);
 

--- a/test/tester.h
+++ b/test/tester.h
@@ -16,12 +16,18 @@
 
 #include <iostream>
 #include <type_traits>
+#include <limits>
+
+
+//type and limit of fail threshold
+using fail_threshold_type = unsigned short;
+static constexpr fail_threshold_type max_fail_threshold{ std::numeric_limits<fail_threshold_type>::max() };
 
 enum class pass_report_mode { none, indicate, detail };
 
 void set_header_text(std::string text);
 void set_pass_report_mode(pass_report_mode mode);
-void set_fail_threshold(unsigned short value);
+void set_fail_threshold(fail_threshold_type value);
 void set_max_fail_threshold();
 void set_output(std::ostream& o);
 

--- a/test/tester.h
+++ b/test/tester.h
@@ -35,6 +35,4 @@ void start_suite(const std::string& name);
 void summarize_suite();
 void summarize_tests();
 
-void verify(bool success, const char* msg);
-
 #endif

--- a/test/verifier-exceptions.h
+++ b/test/verifier-exceptions.h
@@ -1,0 +1,52 @@
+/*
+* verifier-exceptions.h
+* Sean Murthy
+* (c) 2020 sigcpp https://sigcpp.github.io. See LICENSE.MD
+*
+* Attribution and copyright notice must be retained.
+* - Attribution may be augmented to include additional authors
+* - Copyright notice cannot be altered
+* Attribution and copyright info may be relocated but they must be conspicuous.
+*
+* Define verifier-related exceptions
+*/
+
+#ifndef STL_LITE_VERIFIER_EXCEPTIONS_H
+#define STL_LITE_VERIFIER_EXCEPTIONS_H
+
+#include <stdexcept>
+#include <string_view>
+#include <string>
+
+#include "utils.h"
+
+//base class for verifier errors
+class verifier_error : public std::runtime_error {
+
+public:
+	verifier_error(const std::string_view& base) : std::runtime_error{ format_message(base) } {}
+
+	verifier_error(const std::string_view& base, const std::string& details) :
+		std::runtime_error{ format_message(base, details) },
+		details_{ details } {}
+
+	const std::string& details() const noexcept
+	{
+		return details_;
+	}
+
+private:
+	std::string details_;
+};
+
+
+class fail_threshold_met_error : public verifier_error {
+
+public:
+	fail_threshold_met_error() : verifier_error{ base } {}
+
+private:
+	static constexpr std::string_view base{ "fail threshold met" };
+};
+
+#endif


### PR DESCRIPTION
The changes in this PR fix issues assigned to M5. This PR should be closed as the last act of closing M5. This PR summary to be updated with additional issues fixed as the day proceeds and more issues are fixed.

Fixes #22, #24 

Summary of changes:
- Custom error classes for verifier errors (including fail threshold met)
- Handle verifier errors and completely revamp error handling in test driver
- Change data type of counters and fail threshold to `int` in tester 